### PR TITLE
Split unboxing in two: HW and SW

### DIFF
--- a/O3R/GettingStarted/README.md
+++ b/O3R/GettingStarted/README.md
@@ -2,7 +2,8 @@
 
 | Table of content|
 |-|
-| [Unboxing](../GettingStarted/unboxing.md)|
+| [Hardware Unboxing](../GettingStarted/hw_unboxing.md)|
+| [Software Installation](../GettingStarted/sw_installation.md)|
 | [Basic tutorials](https://ifm.github.io/ifm3d-docs/examples/o3r/index.html)|
 
 This section should help you with the first steps using the O3R.

--- a/O3R/GettingStarted/hw_unboxing.md
+++ b/O3R/GettingStarted/hw_unboxing.md
@@ -1,0 +1,19 @@
+# Hardware unboxing
+
+If nobody tampered with your O3R package, you should have following hardware:
+- Camera head (two of them if you ordered the developer kit)
+![HEAD](./resources/head.jpg "O3R - HEAD")
+- VPU (Video Processing Unit)  
+![VPU](./resources/vpu.jpg "O3R - VPU")
+- FPD cables to connect the head(s) to the VPU
+
+
+You need a strong enough power source: 2.5A and 24V minimum.
+
+1) First, connect the head(s) to the VPU; the only requirement is to connect pairs of same imager types together, for instance as shown below:  
+![CONNECTION-OVERVIEW](./resources/connection_overview.png "Connections")  
+2) Connect power to the VPU - <font color=red>ATTENTION: PIN2 is power! PIN3 is ground</font>   
+3) Connect the ethernet cable (not included in the package)  
+4) Wait until you see the ethernet LED flashing before pinging/connecting to the VPU.  
+
+That's it about the hardware. Next step: [software installation](sw_installation.md).

--- a/O3R/GettingStarted/sw_installation.md
+++ b/O3R/GettingStarted/sw_installation.md
@@ -1,24 +1,4 @@
-# How to: Unboxing O3R
-
-## Hardware unboxing
-
-If nobody tampered with your O3R package, you should have following hardware:
-- Camera head (two of them if you ordered the developer kit)
-![HEAD](./resources/head.jpg "O3R - HEAD")
-- VPU (Video Processing Unit)  
-![VPU](./resources/vpu.jpg "O3R - VPU")
-- FPD cables to connect the head(s) to the VPU
-
-
-You need a strong enough power source: 2.5A and 24V minimum.
-
-1) First, connect the head(s) to the VPU; the only requirement is to connect pairs of same imager types together, for instance as shown below:  
-![CONNECTION-OVERVIEW](./resources/connection_overview.png "Connections")  
-2) Connect power to the VPU - <font color=red>ATTENTION: PIN2 is power! PIN3 is ground</font>   
-3) Connect the ethernet cable (not included in the package)  
-4) Wait until you see the ethernet LED flashing before pinging/connecting to the VPU.  
-
-That's it about the hardware. Next step: software installation.
+# Software installation
 
 ## Network configuration
 The default IP address of the VPU is 192.168.0.69. A good first step is to make sure you can connect to the VPU:


### PR DESCRIPTION
Feedback from GP: splitting HW and SW unboxing makes more sense, as it will be more simple to find the SW instructions if they are separate than if one has to scroll down the unboxing page to find the SW installation instructions.